### PR TITLE
Support multiple options (-vo as -v -o)

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -64,6 +64,7 @@ command_init(command_t *self, const char *name, const char *version) {
   self->version = version;
   self->option_count = self->argc = 0;
   self->usage = "[options]";
+  self->nargv = NULL;
   command_option(self, "-V", "--version", "output program version", command_version);
   command_option(self, "-h", "--help", "output help information", command_help);
 }
@@ -209,8 +210,7 @@ command_parse_args(command_t *self, int argc, char **argv) {
 
     int n = self->argc++;
     if (n == COMMANDER_MAX_ARGS) error("Maximum number of arguments exceeded");
-    self->argv[n] = malloc(strlen(arg) + 1);
-    strcpy(self->argv[n], arg);
+    self->argv[n] = (char *) arg;
     match:;
   }
 }
@@ -221,8 +221,6 @@ command_parse_args(command_t *self, int argc, char **argv) {
 
 void
 command_parse(command_t *self, int argc, char **argv) {
-  char **nargv = normalize_args(&argc, argv);
-  command_parse_args(self, argc, nargv);
-  for (int i = 0; i < argc; i++) free(nargv[i]);
-  free(nargv);
+  self->nargv = normalize_args(&argc, argv);
+  command_parse_args(self, argc, self->nargv);
 }

--- a/src/commander.h
+++ b/src/commander.h
@@ -65,6 +65,7 @@ typedef struct command {
   command_option_t options[COMMANDER_MAX_OPTIONS];
   int argc;
   char *argv[COMMANDER_MAX_ARGS];
+  char **nargv;
 } command_t;
 
 // prototypes


### PR DESCRIPTION
To keep things simple I've retained the following design:

There is a first pass (a.k.a normalize) whose job is to create a clone of the input argument vector with multiple options properly exploded, e.g:

```
(input) foo -abc --scm git
(output) foo -a -b -c --scm git
```

This _normalized_ input vector is then parsed in a second pass. This is done as usual, with the former function that has been kept untouched [1].

Note that in my own fork (master branch) I've included the additional arguments deletion at `command_clean` time.

[1] except that the additional arguments are now copied. This is required since:
- we no more reference the original argument vector,
- the normalized `argv` is flushed out after `command_parse`.
