### PR TITLE
Fixed warning when compiling with -Wshorten-64-to-32 flag

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -51,7 +51,7 @@ command_help(command_t *self) {
       , option->large_with_arg
       , option->description);
   }
-  
+
   printf("\n");
   exit(0);
 }
@@ -137,7 +137,7 @@ normalize_args(int *argc, char **argv) {
 
   for (i = 0; argv[i]; ++i) {
     const char *arg = argv[i];
-    int len = strlen(arg);
+    size_t len = strlen(arg);
 
     // short flag
     if (len > 2 && '-' == arg[0] && !strchr(arg + 1, '-')) {


### PR DESCRIPTION
Compiling commander with the `-Wshorten-64-to-32` or `-Wconversion` flag generates the following warning:

```
warning: implicit conversion loses integer precision: 'unsigned long' to 'int'
```

Changing the type from `int` to `size_t` fixes it.

PS: Sorry for the whitespace changes. Silly Sublime Text 2!
