### PR TITLE
Fix comparison warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 test: test.c src/commander.c
-	$(CC) $^ -std=c99 -o $@
+	$(CC) $^ -std=c99 -o $@ -Wall -Wextra
 
 clean:
 	rm -f test

--- a/src/commander.c
+++ b/src/commander.c
@@ -135,7 +135,7 @@ normalize_args(int *argc, char **argv) {
   int size = 0;
   int alloc = *argc + 1;
   char **nargv = malloc(alloc * sizeof(char *));
-  int i, j;
+  int i;
 
   for (i = 0; argv[i]; ++i) {
     const char *arg = argv[i];
@@ -145,7 +145,7 @@ normalize_args(int *argc, char **argv) {
     if (len > 2 && '-' == arg[0] && !strchr(arg + 1, '-')) {
       alloc += len - 2;
       nargv = realloc(nargv, alloc * sizeof(char *));
-      for (j = 1; j < len; ++j) {
+      for (size_t j = 1; j < len; ++j) {
         nargv[size] = malloc(3);
         sprintf(nargv[size], "-%c", arg[j]);
         size++;


### PR DESCRIPTION
Silence the warning: “… comparison of integers of different signs: 'int' and 'size_t’”.
