### PR TITLE
Feature: added support for C++

### DIFF
--- a/src/commander.h
+++ b/src/commander.h
@@ -24,6 +24,10 @@
 #define COMMANDER_MAX_ARGS 32
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+namespace commander {
+#endif
 /*
  * Command struct.
  */
@@ -85,4 +89,8 @@ command_option(command_t *self, const char *small, const char *large, const char
 void
 command_parse(command_t *self, int argc, char **argv);
 
+#ifdef __cplusplus
+}
+}
+#endif /* __cplusplus */
 #endif /* COMMANDER_H */


### PR DESCRIPTION
Hi,
I've added ifdef guards to `commander.h` to ensure compatibility with C++. Specifically, I have:
- Created an `extern "C"` block to ensure ABI compatibility
- Created a `commander` namespace. The effects of this change in particular can easily be reverted by stating `using namespace commander;`

Best regards.